### PR TITLE
add:commit-13

### DIFF
--- a/Server/domain/agent/types.ts
+++ b/Server/domain/agent/types.ts
@@ -2,11 +2,51 @@ export type AgentMessageRole = "user" | "assistant" | "system";
 
 export type AgentRunStatus = "proposed" | "approved" | "rejected" | "executed" | "failed";
 
+export type AgentDistributionMode = "capacity";
+
+export type AgentSkillLevel =
+	| "beginner"
+	| "junior"
+	| "intermediate"
+	| "mid"
+	| "senior"
+	| "expert"
+	| "principal";
+
+export interface AgentProjectIntent {
+	mode: "create" | "update";
+	name: string;
+}
+
+export interface AgentMemberSkillIntent {
+	name: string;
+	level: AgentSkillLevel | null;
+	years: number | null;
+}
+
+export interface AgentMemberIntent {
+	name: string;
+	resolution: "existing" | "new" | "ambiguous";
+	existingPersonId: string | null;
+	candidateMatches: Array<{ id: string; name: string }>;
+	weeklyCapacityHours: number | null;
+	skills: AgentMemberSkillIntent[];
+}
+
+export interface AgentIntentPayload {
+	project: AgentProjectIntent | null;
+	tasks: string[];
+	members: AgentMemberIntent[];
+	distributionMode: AgentDistributionMode | null;
+	followUps: string[];
+}
+
 export interface AgentProposal {
 	mode: "proposal_only";
 	summary: string;
 	rawMessage: string;
 	generatedAt: string;
+	intent: AgentIntentPayload;
 	actions: Array<{
 		type: string;
 		description: string;

--- a/Server/use-cases/agent/chatService.test.ts
+++ b/Server/use-cases/agent/chatService.test.ts
@@ -1,0 +1,129 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import { AgentChatService, AgentChatServiceLive } from "./chatService.js";
+import type { AgentRepository } from "./repository.js";
+import { AgentRepository as AgentRepositoryTag } from "./repository.js";
+
+const createRepositoryLayer = (
+	search: (name: string) => Array<{
+		id: string;
+		name: string;
+		weeklyCapacityHours: number | null;
+		currentLoadHours?: number;
+	}>,
+): Layer.Layer<AgentRepository> =>
+	Layer.succeed(AgentRepositoryTag, {
+		createConversation: (input) =>
+			Effect.succeed({
+				id: "conversation-1",
+				title: input?.title ?? null,
+				createdAt: new Date("2026-02-09T00:00:00.000Z"),
+				updatedAt: new Date("2026-02-09T00:00:00.000Z"),
+			}),
+		appendMessage: (input) =>
+			Effect.succeed({
+				id: `message-${input.role.toLowerCase()}`,
+				conversationId: input.conversationId,
+				role: input.role,
+				content: input.content,
+				createdAt: new Date("2026-02-09T00:00:00.000Z"),
+			}),
+		createRun: (input) =>
+			Effect.succeed({
+				id: "run-1",
+				conversationId: input.conversationId,
+				status: input.status ?? "PROPOSED",
+				input: input.data.input,
+				proposal: input.data.proposal,
+				createdAt: new Date("2026-02-09T00:00:00.000Z"),
+				updatedAt: new Date("2026-02-09T00:00:00.000Z"),
+			}),
+		getConversationSnapshot: () => Effect.succeed(null),
+		searchPeopleByName: (name) =>
+			Effect.succeed(
+				search(name).map((person) => ({
+					id: person.id,
+					name: person.name,
+					weeklyCapacityHours: person.weeklyCapacityHours,
+					currentLoadHours: person.currentLoadHours ?? 0,
+					skills: [],
+				})),
+			),
+	} as AgentRepository);
+
+const runChat = async (
+	message: string,
+	search: (name: string) => Array<{ id: string; name: string; weeklyCapacityHours: number | null }>,
+) =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const service = yield* AgentChatService;
+			return yield* service.chat({ message });
+		}).pipe(
+			Effect.provide(Layer.provideMerge(AgentChatServiceLive, createRepositoryLayer(search))),
+		),
+	);
+
+describe("AgentChatService intent parsing", () => {
+	it("parses project/tasks/members and resolves existing people", async () => {
+		const result = await runChat(
+			"New project Phoenix, add tasks API/Frontend/QA, include Sam and Maya, distribute by capacity",
+			(name) => {
+				if (name.toLowerCase() === "sam") {
+					return [{ id: "person-sam", name: "Sam", weeklyCapacityHours: 35 }];
+				}
+				return [];
+			},
+		);
+
+		expect(result.proposal.intent.project?.name).toBe("Phoenix");
+		expect(result.proposal.intent.tasks).toEqual(["API", "Frontend", "QA"]);
+		expect(result.proposal.intent.distributionMode).toBe("capacity");
+
+		const sam = result.proposal.intent.members.find((member) => member.name === "Sam");
+		const maya = result.proposal.intent.members.find((member) => member.name === "Maya");
+		expect(sam?.resolution).toBe("existing");
+		expect(sam?.existingPersonId).toBe("person-sam");
+		expect(maya?.resolution).toBe("new");
+		expect(result.proposal.intent.followUps).toContain(
+			"What weekly capacity (hours/week) should I use for Maya?",
+		);
+	});
+
+	it("returns clarification prompt for ambiguous member names", async () => {
+		const result = await runChat(
+			"New project Atlas, add tasks API, include Sam, distribute by capacity",
+			(name) => {
+				if (name.toLowerCase() === "sam") {
+					return [
+						{ id: "person-sam-1", name: "Sam Rodriguez", weeklyCapacityHours: 40 },
+						{ id: "person-sam-2", name: "Sam Lee", weeklyCapacityHours: 30 },
+					];
+				}
+				return [];
+			},
+		);
+
+		const sam = result.proposal.intent.members.find((member) => member.name === "Sam");
+		expect(sam?.resolution).toBe("ambiguous");
+		expect(
+			result.proposal.intent.followUps.some((question) =>
+				question.includes("Which Sam do you mean"),
+			),
+		).toBe(true);
+	});
+
+	it("asks for skill level when skill was provided without one", async () => {
+		const result = await runChat(
+			"New project Atlas, add tasks API, include Maya: TypeScript 3y, distribute by capacity",
+			() => [],
+		);
+
+		const maya = result.proposal.intent.members.find((member) => member.name === "Maya");
+		expect(maya?.skills[0]?.name.toLowerCase()).toBe("typescript");
+		expect(maya?.skills[0]?.level).toBeNull();
+		expect(result.proposal.intent.followUps).toContain(
+			"What level should I record for Maya's TypeScript skill?",
+		);
+	});
+});

--- a/Server/use-cases/agent/intentParser.ts
+++ b/Server/use-cases/agent/intentParser.ts
@@ -1,0 +1,259 @@
+import type {
+	AgentDistributionMode,
+	AgentMemberSkillIntent,
+	AgentProjectIntent,
+	AgentSkillLevel,
+} from "../../domain/agent/types.js";
+
+export interface ParsedMemberDraft {
+	name: string;
+	weeklyCapacityHours: number | null;
+	skills: AgentMemberSkillIntent[];
+}
+
+export interface ParsedIntentDraft {
+	project: AgentProjectIntent | null;
+	tasks: string[];
+	members: ParsedMemberDraft[];
+	distributionMode: AgentDistributionMode | null;
+}
+
+const LEVEL_ALIASES: Record<string, AgentSkillLevel> = {
+	beginner: "beginner",
+	junior: "junior",
+	intermediate: "intermediate",
+	mid: "mid",
+	senior: "senior",
+	expert: "expert",
+	principal: "principal",
+	sr: "senior",
+	snr: "senior",
+};
+
+const LEVEL_PATTERNS = Object.keys(LEVEL_ALIASES).sort((a, b) => b.length - a.length);
+
+const normalize = (value: string) => value.trim().replace(/\s+/g, " ");
+
+const dequote = (value: string) => value.replace(/^["'`]+|["'`]+$/g, "").trim();
+
+const dedupe = (values: string[]) => {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (const value of values) {
+		const normalized = value.toLowerCase();
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+		result.push(value);
+	}
+	return result;
+};
+
+const splitOutsideParens = (input: string, separators: string[] = [",", "/", ";"]) => {
+	const parts: string[] = [];
+	let current = "";
+	let depth = 0;
+
+	for (let i = 0; i < input.length; i += 1) {
+		const ch = input[i];
+		if (ch === "(") depth += 1;
+		if (ch === ")") depth = Math.max(0, depth - 1);
+
+		if (depth === 0 && separators.includes(ch)) {
+			if (current.trim()) parts.push(current.trim());
+			current = "";
+			continue;
+		}
+
+		current += ch;
+	}
+
+	if (current.trim()) parts.push(current.trim());
+	return parts;
+};
+
+const parseYears = (input: string): number | null => {
+	const match = input.match(/\b(\d{1,3})\s*(?:y|yr|yrs|year|years)\b/i);
+	if (!match) return null;
+	const parsed = Number.parseInt(match[1], 10);
+	return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseLevel = (input: string): AgentSkillLevel | null => {
+	const lower = input.toLowerCase();
+	for (const key of LEVEL_PATTERNS) {
+		const regex = new RegExp(`\\b${key}\\b`, "i");
+		if (regex.test(lower)) {
+			return LEVEL_ALIASES[key] ?? null;
+		}
+	}
+	return null;
+};
+
+const removeLevelAndYears = (input: string) => {
+	let cleaned = input;
+	cleaned = cleaned.replace(/\b\d{1,3}\s*(?:y|yr|yrs|year|years)\b/gi, "");
+	for (const key of LEVEL_PATTERNS) {
+		const regex = new RegExp(`\\b${key}\\b`, "gi");
+		cleaned = cleaned.replace(regex, "");
+	}
+	return cleaned
+		.replace(/\b(skills?|with|at|level)\b/gi, "")
+		.replace(/\s+/g, " ")
+		.trim();
+};
+
+const parseSkillEntries = (raw: string): AgentMemberSkillIntent[] => {
+	const segments = splitOutsideParens(raw.replace(/\band\b/gi, ","));
+	const skills: AgentMemberSkillIntent[] = [];
+	for (const segment of segments) {
+		const candidate = normalize(segment);
+		if (!candidate) continue;
+		const level = parseLevel(candidate);
+		const years = parseYears(candidate);
+		const skillName = dequote(removeLevelAndYears(candidate)).replace(/^[:-]\s*/, "");
+		if (!skillName) continue;
+		skills.push({
+			name: skillName,
+			level,
+			years,
+		});
+	}
+	return skills;
+};
+
+const parseMemberToken = (token: string): ParsedMemberDraft | null => {
+	const normalized = normalize(token);
+	if (!normalized) return null;
+
+	const parenMatch = normalized.match(/^(.+?)\s*\((.+)\)$/);
+	const colonIdx = normalized.indexOf(":");
+	const hasColon = colonIdx > 0;
+
+	let rawName = normalized;
+	let rawSkillDetails = "";
+	if (parenMatch) {
+		rawName = normalize(parenMatch[1]);
+		rawSkillDetails = normalize(parenMatch[2]);
+	} else if (hasColon) {
+		rawName = normalize(normalized.slice(0, colonIdx));
+		rawSkillDetails = normalize(normalized.slice(colonIdx + 1));
+	}
+
+	const capacityMatch = normalized.match(
+		/\b(\d{1,2})\s*(?:h|hr|hrs|hour|hours)(?:\s*\/?\s*w(?:eek)?)?\b/i,
+	);
+	const weeklyCapacityHours = capacityMatch ? Number.parseInt(capacityMatch[1], 10) : null;
+
+	const name = dequote(
+		rawName
+			.replace(/\b(include|add|member|members|people|team|and|with)\b/gi, " ")
+			.replace(/\b\d{1,2}\s*(?:h|hr|hrs|hour|hours)(?:\s*\/?\s*w(?:eek)?)?\b/gi, " "),
+	).trim();
+	if (!name) return null;
+
+	const skills = rawSkillDetails ? parseSkillEntries(rawSkillDetails) : [];
+	return {
+		name,
+		weeklyCapacityHours: Number.isFinite(weeklyCapacityHours ?? Number.NaN)
+			? weeklyCapacityHours
+			: null,
+		skills,
+	};
+};
+
+const parseProject = (segments: string[]): AgentProjectIntent | null => {
+	for (const segment of segments) {
+		const normalized = normalize(segment);
+		const createMatch = normalized.match(/\bnew project\b[:\s-]*(.+)$/i);
+		if (createMatch) {
+			const name = dequote(
+				createMatch[1].split(/\b(?:add tasks?|include|with|distribute)\b/i)[0] ?? "",
+			);
+			if (name) return { mode: "create", name: normalize(name) };
+		}
+		const updateMatch = normalized.match(/\bproject\b[:\s-]*(.+)$/i);
+		if (updateMatch) {
+			const name = dequote(
+				updateMatch[1].split(/\b(?:add tasks?|include|with|distribute)\b/i)[0] ?? "",
+			);
+			if (name) return { mode: "update", name: normalize(name) };
+		}
+	}
+	return null;
+};
+
+const parseTasks = (segments: string[]): string[] => {
+	const tasks: string[] = [];
+	for (const segment of segments) {
+		if (!/\btasks?\b/i.test(segment)) continue;
+		const tail = segment.replace(/^.*?\btasks?\b[:\s-]*/i, "").trim();
+		if (!tail) continue;
+		for (const part of splitOutsideParens(tail.replace(/\band\b/gi, ","))) {
+			const task = dequote(part);
+			if (task) tasks.push(normalize(task));
+		}
+	}
+	return dedupe(tasks);
+};
+
+const parseMembers = (segments: string[]): ParsedMemberDraft[] => {
+	const members: ParsedMemberDraft[] = [];
+	for (const segment of segments) {
+		if (!/\b(include|members?|people|team)\b/i.test(segment)) continue;
+		const tail = segment
+			.replace(/^.*?\b(include|members?|people|team)\b[:\s-]*/i, "")
+			.replace(/\bdistribut(?:e|ion)\b.*$/i, "")
+			.trim();
+		if (!tail) continue;
+
+		const candidates = splitOutsideParens(tail.replace(/\band\b/gi, ","));
+		for (const candidate of candidates) {
+			const parsed = parseMemberToken(candidate);
+			if (parsed) members.push(parsed);
+		}
+	}
+
+	const deduped = new Map<string, ParsedMemberDraft>();
+	for (const member of members) {
+		const key = member.name.toLowerCase();
+		const existing = deduped.get(key);
+		if (!existing) {
+			deduped.set(key, member);
+			continue;
+		}
+		const weeklyCapacityHours = existing.weeklyCapacityHours ?? member.weeklyCapacityHours;
+		const skills = [...existing.skills, ...member.skills];
+		deduped.set(key, {
+			name: existing.name,
+			weeklyCapacityHours,
+			skills: dedupe(
+				skills.map(
+					(skill) => `${skill.name.toLowerCase()}|${skill.level ?? ""}|${skill.years ?? ""}`,
+				),
+			).map((keyed) => {
+				const [name, level, years] = keyed.split("|");
+				return {
+					name,
+					level: (level || null) as AgentSkillLevel | null,
+					years: years ? Number.parseInt(years, 10) : null,
+				};
+			}),
+		});
+	}
+
+	return [...deduped.values()];
+};
+
+const parseDistributionMode = (message: string): AgentDistributionMode | null =>
+	/\b(capacity|available hours?|workload)\b/i.test(message) ? "capacity" : null;
+
+export const parseIntentDraft = (message: string): ParsedIntentDraft => {
+	const normalized = normalize(message);
+	const segments = normalized.split(/[\n,]+/).map((segment) => segment.trim());
+	return {
+		project: parseProject(segments),
+		tasks: parseTasks(segments),
+		members: parseMembers(segments),
+		distributionMode: parseDistributionMode(normalized),
+	};
+};

--- a/Server/use-cases/agent/repository.ts
+++ b/Server/use-cases/agent/repository.ts
@@ -43,6 +43,18 @@ export type AgentConversationSnapshot = {
 	actions: AgentActionRecord[];
 };
 
+export type AgentPersonRecord = {
+	id: string;
+	name: string;
+	weeklyCapacityHours: number | null;
+	currentLoadHours: number;
+	skills: Array<{
+		name: string;
+		level: string | null;
+		years: number | null;
+	}>;
+};
+
 export interface AgentRepository {
 	createConversation: (input?: {
 		title?: string | null;
@@ -63,6 +75,7 @@ export interface AgentRepository {
 	getConversationSnapshot: (
 		conversationId: string,
 	) => Effect.Effect<AgentConversationSnapshot | null, AgentRepositoryError>;
+	searchPeopleByName: (name: string) => Effect.Effect<AgentPersonRecord[], AgentRepositoryError>;
 }
 
 export const AgentRepository = Context.GenericTag<AgentRepository>("AgentRepository");

--- a/execPlan.md
+++ b/execPlan.md
@@ -20,7 +20,7 @@ Context: skeleton app exists (Client React Router shell, Server Hono health chec
 - [x] Commit 10 — CI/CD and ops hardening
 - [ ] Commit 11 — Evaluation & polish
 - [x] Commit 12 — Agent chat domain & storage
-- [ ] Commit 13 — Chat intent parsing (project/tasks/members/skills)
+- [x] Commit 13 — Chat intent parsing (project/tasks/members/skills)
 - [ ] Commit 14 — Capacity distribution + approval execution
 - [ ] Commit 15 — Chat UI with proposal cards
 - [ ] Commit 16 — Chat-agent test matrix & rollout docs
@@ -294,25 +294,25 @@ Introduce a chat-first execution model with auditable proposals.
 
 ---
 
-### Commit 13 — Chat intent parsing (project/tasks/members/skills)
+### Commit 13 — Chat intent parsing (project/tasks/members/skills) ✅
 Parse user chat like: "New project X, add tasks A/B/C, include Sam and Maya, distribute by capacity."
 
 **Features**
-- [ ] Add intent parser output schema:
-  - [ ] `project` (create/update)
-  - [ ] `tasks[]`
-  - [ ] `members[]` (new/existing)
-  - [ ] `skills[]` per member (`name`, `level`, optional `years`)
-  - [ ] `distributionMode` (`capacity`)
-- [ ] Resolve existing people by name (with ambiguity handling)
-- [ ] Upsert new members + skill profiles in proposal preview (not applied yet)
-- [ ] Ask structured follow-ups for missing fields:
-  - [ ] weekly capacity missing
-  - [ ] skill level missing for required skill
+- [x] Add intent parser output schema:
+  - [x] `project` (create/update)
+  - [x] `tasks[]`
+  - [x] `members[]` (new/existing/ambiguous)
+  - [x] `skills[]` per member (`name`, `level`, optional `years`)
+  - [x] `distributionMode` (`capacity`, defaulted when omitted)
+- [x] Resolve existing people by name (with ambiguity handling)
+- [x] Upsert new members + skill profiles in proposal preview (not applied yet)
+- [x] Ask structured follow-ups for missing fields:
+  - [x] weekly capacity missing
+  - [x] skill level missing for required skill
 
 **Definition of done**
-- [ ] Chat input reliably generates a structured proposal card with parsed members and skills
-- [ ] Ambiguous people names return clarification prompts instead of bad assumptions
+- [x] Chat input reliably generates a structured proposal payload with parsed members and skills
+- [x] Ambiguous people names return clarification prompts instead of bad assumptions
 
 ---
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add intent parser for extracting project, tasks, members, and skills from chat

- Implement member resolution with existing person lookup and ambiguity detection

- Generate structured follow-up questions for missing capacity and skill levels

- Add comprehensive test suite for intent parsing and member resolution logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ChatInput["Chat Input Message"] -->|parseIntentDraft| Parser["Intent Parser"]
  Parser -->|extract project/tasks/members| Draft["Parsed Draft"]
  Draft -->|searchPeopleByName| Repo["Agent Repository"]
  Repo -->|person records| Resolution["Member Resolution"]
  Resolution -->|resolve existing/new/ambiguous| Members["Resolved Members"]
  Members -->|buildFollowUps| FollowUps["Follow-up Questions"]
  FollowUps -->|create proposal| Proposal["Agent Proposal with Intent"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add intent parsing domain types and interfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Server/domain/agent/types.ts

<ul><li>Add <code>AgentDistributionMode</code> type for capacity-based distribution<br> <li> Add <code>AgentSkillLevel</code> enum with 7 proficiency levels (beginner to <br>principal)<br> <li> Add <code>AgentProjectIntent</code> interface for project create/update operations<br> <li> Add <code>AgentMemberSkillIntent</code> interface with name, level, and years<br> <li> Add <code>AgentMemberIntent</code> interface with resolution status and candidate <br>matches<br> <li> Add <code>AgentIntentPayload</code> interface containing project, tasks, members, <br>distribution mode, and follow-ups<br> <li> Extend <code>AgentProposal</code> with <code>intent</code> field to store parsed intent payload</ul>


</details>


  </td>
  <td><a href="https://github.com/marzun9620/goalFlow-agent/pull/27/files#diff-7dd318489a2758770cfd881477b604652fa17352eb3a8da6c43fe8d129d35a5a">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>intentParser.ts</strong><dd><code>Implement natural language intent parser for chat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Server/use-cases/agent/intentParser.ts

<ul><li>Implement <code>parseIntentDraft</code> function to extract project, tasks, <br>members, and distribution mode from chat<br> <li> Add skill parsing with level aliases (sr/snr → senior) and year <br>extraction<br> <li> Implement member token parsing supporting parentheses and colon syntax <br>for skills<br> <li> Add deduplication logic for members and skills with case-insensitive <br>matching<br> <li> Implement helper functions for splitting outside parentheses, <br>normalizing text, and removing quotes<br> <li> Support multiple separators (comma, slash, semicolon) for parsing <br>lists</ul>


</details>


  </td>
  <td><a href="https://github.com/marzun9620/goalFlow-agent/pull/27/files#diff-11ec45c894b0c7810e7b99684f25856375a3249d6af141e525d846071176bed8">+259/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chatService.ts</strong><dd><code>Integrate intent parsing into proposal generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Server/use-cases/agent/chatService.ts

<ul><li>Add <code>resolveMemberIntent</code> function to match member names against <br>existing people with exact/partial/ambiguous resolution<br> <li> Implement <code>buildFollowUps</code> function to generate clarification questions <br>for missing project, capacity, and skill levels<br> <li> Implement <code>makeSummary</code> function to create proposal summary with member <br>resolution statistics<br> <li> Refactor <code>makeProposal</code> to be async Effect-based, integrating intent <br>parsing and member resolution<br> <li> Update proposal actions to include resolve_members, preview_upserts, <br>and collect_followups steps<br> <li> Modify chat service to call repository's <code>searchPeopleByName</code> during <br>proposal generation</ul>


</details>


  </td>
  <td><a href="https://github.com/marzun9620/goalFlow-agent/pull/27/files#diff-87a661fa365e349554e1bc7e4974207fa8966d31458e34f51c306d0b9ca81c4f">+170/-15</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agentRepository.ts</strong><dd><code>Add person search capability to agent repository</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Server/repositories/agentRepository.ts

<ul><li>Add <code>searchPeopleByName</code> method to find people by name with <br>case-insensitive search<br> <li> Include person skills with skill names and levels in search results<br> <li> Return top 10 matches ordered by name, with weekly capacity and <br>current load hours<br> <li> Map skill levels to lowercase for consistency with domain types</ul>


</details>


  </td>
  <td><a href="https://github.com/marzun9620/goalFlow-agent/pull/27/files#diff-45d04ccef3802ff16c256f9e8c3845eef89062f037d2f1906c95d4276719a27e">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repository.ts</strong><dd><code>Add person search types to repository interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Server/use-cases/agent/repository.ts

<ul><li>Add <code>AgentPersonRecord</code> type with id, name, capacity, load hours, and <br>skills array<br> <li> Add <code>searchPeopleByName</code> method signature to <code>AgentRepository</code> interface<br> <li> Define skill record structure with name, level, and years fields</ul>


</details>


  </td>
  <td><a href="https://github.com/marzun9620/goalFlow-agent/pull/27/files#diff-578ee553febd7380e5c5646bc8dfafee15242a21ffc7963869054d0e67a1e7a8">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatService.test.ts</strong><dd><code>Add intent parsing test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Server/use-cases/agent/chatService.test.ts

<ul><li>Add comprehensive test suite for intent parsing with 3 test cases<br> <li> Test project/tasks/members parsing with existing person resolution<br> <li> Test ambiguous member name handling with multiple candidate matches<br> <li> Test skill parsing without level and follow-up question generation<br> <li> Implement mock repository layer for testing with configurable person <br>search</ul>


</details>


  </td>
  <td><a href="https://github.com/marzun9620/goalFlow-agent/pull/27/files#diff-47e797ceb37491c9aeeac81cf8af0c1041f13b373a70d459496b99c01974aa72">+129/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>execPlan.md</strong><dd><code>Mark Commit 13 as complete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

execPlan.md

<ul><li>Mark Commit 13 as completed with checkmark<br> <li> Update all feature checkboxes to completed status<br> <li> Update definition of done items to completed status<br> <li> Clarify member resolution includes new/existing/ambiguous states<br> <li> Note that distribution mode defaults to capacity when omitted</ul>


</details>


  </td>
  <td><a href="https://github.com/marzun9620/goalFlow-agent/pull/27/files#diff-3fd4e88e22a9d9f0c81808312df367f89e548486d4a9b1a0785b0c29ed469833">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

